### PR TITLE
feat: support %IPM 0.9+

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -4,7 +4,7 @@
     <Module>
       <Name>zpip</Name>
       <GlobalScope>true</GlobalScope>
-      <Version>0.0.5</Version>
+      <Version>0.0.6</Version>
       <Description>Use pip from the intersystems terminal</Description>
       <Keywords>pip python</Keywords>
       <Packaging>module</Packaging>

--- a/src/%ZPIP/zpip.cls
+++ b/src/%ZPIP/zpip.cls
@@ -1,5 +1,3 @@
-Include %ZPM.PackageManager.Common
-
 /// Used for version check
 Class %ZPIP.zpip
 {
@@ -8,7 +6,7 @@ ClassMethod Shell(pArgs)
 {
     #; Gets the install directory
     Set InstallDir = $SYSTEM.Util.InstallDirectory()
-    Set pythonbin = InstallDir _  $$$SLASH _ "bin" _  $$$SLASH _ "irispython"
+    Set pythonbin = ##class(%File).Construct(InstallDir,"bin","irispython")
   
     #; pip3 install <packages>
 


### PR DESCRIPTION
Hi @nickmitchko . InterSystems is going to roll out a newer version of package manager, IPM, which introduces new features and breaking changes. One of such change is that we renamed the whole %ZPM package to %IPM. This PR ensures that this package will be compatible with both older and newer version of the package manager.